### PR TITLE
FIX: voice - utils - getMusicLength

### DIFF
--- a/src/utils/voice.ts
+++ b/src/utils/voice.ts
@@ -3,7 +3,7 @@ import { cache, DiscordenoMessage, Player, Track } from "../../deps.ts";
 
 /** Convert milliseconds to MM:SS */
 export function getMusicLength(milliseconds: number) {
-  return milliseconds > 3600000
+  return milliseconds >= 3600000
     ? new Date(milliseconds).toISOString().substr(11, 8)
     : new Date(milliseconds).toISOString().substr(14, 5);
 }


### PR DESCRIPTION
This function did not show 1 hour properly.
Example on ts playground: https://www.typescriptlang.org/play?#code/GYVwdgxgLglg9mABAcwKZQLIgM4wgGVTGSgAsAKAWxgBsaZtUIEATbALkTBEoCNUATgEpEAbwBQiRAPQgBSanQZNW2RAD5EAZgBsABgMHJUxAH4uqAO6IAIgEMoqKrXqNmYNkIB0UOAEkAZQB5AKgBGGJyb2wQXmww8gBGRIAaRAAOIWMpTjArWwcnRVcVD2xvX0CQsIjkKK8YuITEgBY0gFYhAG5xAF9xcVBIWAREYBgAD1QWAHF0LFwCIhIKYuV3NlyefmExYxkoOQUXddUNAF5tfUM9bLMLa3tHZyU3VQr-YNDwyOjY+IESVSGSyJkQuXyTyKJzeZQ+VW+tXqjQBSTaiE6PX67mwcBoqC8NDgdQARJYBAhkIgSYgANQoeY4PCEYhkci6G56ITdcQ4vEEomk8ZTFjUuljSbTOaYJlLVkUDk3bk9AD0KsQABVSAxENhSHAQDRRfxEIlEPq5EA