### PR TITLE
FIX: cmd handler - ignore case for commands

### DIFF
--- a/src/monitors/command_handler.ts
+++ b/src/monitors/command_handler.ts
@@ -1,5 +1,5 @@
-import { configs } from "../../configs.ts";
 import { bot } from "../../cache.ts";
+import { configs } from "../../configs.ts";
 import {
   bgBlack,
   bgGreen,
@@ -12,7 +12,7 @@ import {
   DiscordenoMessage,
   green,
   red,
-  white,
+  white
 } from "../../deps.ts";
 import { Command } from "../types/commands.ts";
 import { needMessage } from "../utils/collectors.ts";
@@ -26,6 +26,7 @@ export function parsePrefix(guildId: bigint | undefined) {
 }
 
 export function parseCommand(commandName: string) {
+  commandName = commandName.toLowerCase();
   const command = bot.commands.get(commandName);
   if (command) return command;
 
@@ -168,7 +169,7 @@ async function executeCommand(
     const [argument] = command.arguments || [];
     const subcommand = argument
       ? // deno-lint-ignore no-explicit-any
-        (args[argument.name] as Command<any>)
+      (args[argument.name] as Command<any>)
       : undefined;
 
     if (!argument || argument.type !== "subcommand" || !subcommand) {


### PR DESCRIPTION
Since [command argument](https://github.com/discordeno/template/blob/b1942ad0be368ed8830fe5230268bfc9398e87ec/src/arguments/command.ts#L9) does this I think it would make sense for the command handler to do that too.
