### PR TITLE
i18next - remove ts-ignore, update dd version

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,6 +1,6 @@
 export * from "https://deno.land/std@0.95.0/fmt/colors.ts";
 export * from "https://deno.land/x/sabr@1.1.4/mod.ts";
-export * from "https://deno.land/x/discordeno@11.0.1/mod.ts";
+export * from "https://deno.land/x/discordeno@11.2.0/mod.ts";
 export {
   Manager,
   Player,

--- a/src/utils/i18next.ts
+++ b/src/utils/i18next.ts
@@ -58,8 +58,6 @@ export async function loadLanguages() {
         await sendWebhook(
           snowflakeToBigint(configs.webhooks.missingTranslation.id),
           configs.webhooks.missingTranslation.token,
-          // deno-lint-ignore ban-ts-comment
-          // @ts-ignore
           { content: response }
         ).catch(log.error);
       },


### PR DESCRIPTION
I have removed ts-ignore in `src/utils/i18next.ts`, because its not needed. I have also updated the dd version, because the old one refused to work with Deno 1.11.